### PR TITLE
fix: Resolve server error for Broadcast command argument count

### DIFF
--- a/src/ai/ai_controller.py
+++ b/src/ai/ai_controller.py
@@ -159,7 +159,8 @@ class BroadcastManager:
         essential_inventory = {
             k: v for k, v in self.player_state.inventory.items() if k != "food"
         }
-        inv_str = json.dumps(essential_inventory)
+        # Use compact separators to remove spaces from JSON string
+        inv_str = json.dumps(essential_inventory, separators=(',', ':'))
         message = f"BCAST_INV_SHARE;pid={self.player_id};lvl={self.player_state.level};inv={inv_str}"
         return message
 


### PR DESCRIPTION
The Zappy server was reporting an error:
`[Broadcast] : Invalid number of args, expected 1 but got 19.`

This was caused by spaces within the JSON string part of the inventory broadcast message (`BCAST_INV_SHARE;...`). Although the client sends the entire message as a single string argument for the `Broadcast` command, the server was likely tokenizing this argument by spaces.

This commit modifies `BroadcastManager.create_inventory_broadcast` to use `json.dumps(..., separators=(',', ':'))`. This creates a compact JSON string with no extraneous spaces (e.g., after commas or colons).

The resulting broadcast message content (e.g., for inventory share) is now a single continuous string, which should be correctly interpreted by the server as the single expected text argument for the `Broadcast` command.