### PR TITLE
fix: Address L2 stagnation by adjusting food threshold

### DIFF
--- a/src/ai/ai_controller.py
+++ b/src/ai/ai_controller.py
@@ -27,7 +27,8 @@ class SimpleSurvivalManager:
     
     def get_mode(self):
         """Simple 2-level system"""
-        return "SAFE" if self.food_count >= 6 else "HUNGRY"
+        # Increased threshold for SAFE mode to provide a better buffer
+        return "SAFE" if self.food_count >= 9 else "HUNGRY"
 
 import time # Required for PlayerState.player_id
 from collections import Counter # Required for PlayerState._recalculate_shared_inventory


### PR DESCRIPTION
The AI was observed to reach Level 2 and then primarily focus on food gathering, rarely attempting further elevation or forking. This was likely due to a low 'SAFE' mode food threshold, causing the AI to frequently enter 'HUNGRY' mode after the initial incantation (which consumes food). In 'HUNGRY' mode, forking and stone gathering for elevation are deprioritized or disabled.

This commit increases the food count threshold for 'SAFE' mode in `SimpleSurvivalManager.get_mode()` from 6 to 9. This change aims to ensure the AI builds a larger food reserve, allowing it to remain in 'SAFE' mode more consistently after incantations, thereby providing more opportunities to evaluate and attempt forking (already enabled for L2 in a previous commit) and L2+ elevation rituals.